### PR TITLE
added ability to handle object properties which have null values but als...

### DIFF
--- a/dottie.js
+++ b/dottie.js
@@ -104,10 +104,14 @@
 					}
 
 					if (index == (piecesLength - 1)) {
-						current[piece] = object[key];
+						if (current !== null) {
+							current[piece] = object[key];
+						}
 						delete transformed[key];
 					}
-					current = current[piece];
+					if (current != null) {
+						current = current[piece];
+					} else break;
 				}
 			} else {
 				transformed[key] = transformed[key]; // Ensure that properties exist on the object, not just the prototype

--- a/test/transform.test.js
+++ b/test/transform.test.js
@@ -85,4 +85,19 @@ describe("dottie.transform", function () {
 		expect(transformed.customer.name).to.equal('John Doe');
 		expect(transformed.customer.age).to.equal(15);
 	});
+
+	it("should be able to handle null valued properties, not assigning nested level objects", function() {
+		var values = {
+			'section.id': 20,
+			'section.layout': null,
+			'section.layout.id': null,
+			'section.layout.name': null
+		};
+
+		var transformed = dottie.transform(values);
+
+		expect(transformed.section.layout).to.be(null);
+		expect(transformed['section.layout.id']).to.be(undefined);
+		expect(transformed['section.layout.name']).to.be(undefined);
+	});
 });


### PR DESCRIPTION
...o have nested object properties

This change helps sequelize properly handle 1:1 join results which contain null value for joined table
