### PR TITLE
Add support for custom delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Transform object from keys with dottie notation to nested objects
     };
     var transformed = dottie.transform(values);
 
-    transforms is now equal to =
+    // transforms is now equal to =
+
     {
         user: {
             name: 'Mick Hansen',
@@ -46,5 +47,22 @@ Transform object from keys with dottie notation to nested objects
                 title: 'Developer',
                 employer: 'Innofluence'
             }
+        }
+    }
+
+#### With a custom delimiter
+
+    var values = {
+        'user_name': 'Mick Hansen',
+        'user_email': 'mh@innofluence.com'
+    };
+    var transformed = dottie.transform(values, { delimiter: '_' });
+
+    // transforms is now equal to =
+
+    {
+        user: {
+            name: 'Mick Hansen',
+            email: 'mh@innofluence.com'
         }
     }

--- a/dottie.js
+++ b/dottie.js
@@ -90,8 +90,13 @@
 
 	// Transform unnested object with .-seperated keys into a nested object.
 	Dottie.transform = function(object, options) {
+		options = options || {};
+		options.delimiter = options.delimiter || '.';
+
 		if (Array.isArray(object)) {
-			return object.map(Dottie.transform);
+			return object.map(function(o) {
+				return Dottie.transform(o, options);
+			});
 		}
 
 		var pieces,
@@ -101,8 +106,8 @@
 			transformed = {};
 
 		for (var key in object) {
-			if (key.indexOf('.') !== -1) {
-				pieces = key.split('.');
+			if (key.indexOf(options.delimiter) !== -1) {
+				pieces = key.split(options.delimiter);
 				piecesLength = pieces.length;
 				current = transformed;
 

--- a/test/transform.test.js
+++ b/test/transform.test.js
@@ -119,4 +119,30 @@ describe("dottie.transform", function () {
 		expect(transformed[0].customer.name).to.equal('John Doe');
 		expect(transformed[1].client.name).to.equal('John Doe');
 	});
+
+	it("supports custom delimiters", function () {
+		var values = {
+			user: {
+				name: 'John Doe'
+			},
+			'user_email': 'jd@foobar.com',
+			'user_location_country': 'Zanzibar',
+			'user_location_city': 'Zanzibar City',
+			'project_title': 'dottie'
+		};
+
+		var transformed = dottie.transform(values, { delimiter: '_' });
+
+		expect(transformed.user).not.to.be(undefined);
+		expect(transformed.user.location).not.to.be(undefined);
+		expect(transformed.project).not.to.be(undefined);
+
+		expect(transformed.user).to.be.an('object');
+		expect(transformed.user.location).to.be.an('object');
+		expect(transformed.project).to.be.an('object');
+
+		expect(transformed.user.email).to.equal('jd@foobar.com');
+		expect(transformed.user.location.city).to.equal('Zanzibar City');
+		expect(transformed.project.title).to.equal('dottie');
+	});
 });


### PR DESCRIPTION
This PR allows the user to passed the relevant delimiter like this:

```
Dottie.transform(thingy, { delimiter: '_' })
```
