### PR TITLE
Allow date objects and other instances as values in nested objects.

### DIFF
--- a/dottie.js
+++ b/dottie.js
@@ -139,7 +139,7 @@
 		for (var key in object) {
 			if (hasOwnProp.call(object, key)) {
 				current = object[key];
-				if (current === Object(current)) {
+				if (Object.prototype.toString.call(current) === "[object Object]") {
 					nested = Dottie.flatten(current, seperator);
 
 					for (var _key in nested) {


### PR DESCRIPTION
Date objects are removed from objects when flattening. This check is the most reliable way to detect an object to be flattened.

```
var values = {
  some: {
    nested: {
        key: 'foobar',
        date: new Date()
    }
  }
};

Dottie.flatten(values)
> Object {some.nested.key: "foobar", some.nested.date: Thu Jun 19 2014 13:26:13 GMT+0200 (CEST)}
  some.nested.date: Thu Jun 19 2014 13:26:13 GMT+0200 (CEST)
  some.nested.key: "foobar"
  __proto__: Object
```
