### PR TITLE
Fix modification if path input variable

### DIFF
--- a/dottie.js
+++ b/dottie.js
@@ -24,6 +24,18 @@
     }
   };
 
+  var reverseDupArray = function (array) {
+    var result = new Array(array.length);
+    var index  = array.length;
+    var arrayMaxIndex = index - 1;
+
+    while (index--) {
+      result[arrayMaxIndex - index] = array[index];
+    }
+
+    return result;
+  };
+
   var Dottie = function() {
     var args = Array.prototype.slice.call(arguments);
 
@@ -60,7 +72,7 @@
         names = path.split('.').reverse();
       }
     } else if (Array.isArray(path)) {
-      names = path.reverse();
+      names = reverseDupArray(path);
     }
 
     while (names.length && (object = object[names.pop()]) !== undefined && object !== null);

--- a/test/get.test.js
+++ b/test/get.test.js
@@ -95,7 +95,10 @@ describe("dottie.get", function () {
         });
 
         it('should get nested values with keys that have dots', function () {
-          expect(dottie.get(data, ['nested.dot', 'key'])).to.equal('value');
+          var path = ['nested.dot', 'key'];
+
+          expect(dottie.get(data, path)).to.equal('value');
+          expect(path).to.eql(['nested.dot', 'key']);
         });
       });
     });


### PR DESCRIPTION
Previously dottie would modify the incoming path variable it was an
array. It is now duplicating and reversing the array in one step.