### PR TITLE
Don't throw when key is undefined/null

### DIFF
--- a/dottie.js
+++ b/dottie.js
@@ -56,7 +56,9 @@
 
   // Traverse object according to path, return value if found - Return undefined if destination is unreachable
   Dottie.get = function(object, path, defaultVal) {
-    if ((object === undefined) || (object === null)) return defaultVal;
+    if ((object === undefined) || (object === null) || (path === undefined) || (path === null)) {
+        return defaultVal;
+    }
 
     var names;
 

--- a/test/get.test.js
+++ b/test/get.test.js
@@ -55,6 +55,7 @@ describe("dottie.get", function () {
 
         it('should return undefined if key is undefined', function () {
           expect(dottie.get(data, undefined)).to.equal(undefined);
+          expect(dottie.get(data, null)).to.equal(undefined);
           expect(dottie.get(data, undefined, 'default')).to.equal('default');
         });
 

--- a/test/get.test.js
+++ b/test/get.test.js
@@ -53,6 +53,11 @@ describe("dottie.get", function () {
           expect(dottie.get(undefined, 'foo')).to.equal(undefined);
         });
 
+        it('should return undefined if key is undefined', function () {
+          expect(dottie.get(data, undefined)).to.equal(undefined);
+          expect(dottie.get(data, undefined, 'default')).to.equal('default');
+        });
+
         it("should get first-level values", function () {
           expect(dottie.get(data, 'zoo')).to.equal('lander');
           expect(dottie.get(data, 'zoo')).to.equal('lander');


### PR DESCRIPTION
This PR proposes that `dottie.get` should not throw when invoked with an undefined or null key.

Current behavior as of `v1.1.1`:

```
> const dottie = require('dottie')
undefined
> dottie.get({}, undefined)
TypeError: Cannot read property 'length' of undefined
    at Function.Dottie.get (/home/kiwi/sync/projects/linkr/node_modules/dottie/dottie.js:78:17)
    at repl:1:8
    at sigintHandlersWrap (vm.js:22:35)
    at sigintHandlersWrap (vm.js:96:12)
    at ContextifyScript.Script.runInThisContext (vm.js:21:12)
    at REPLServer.defaultEval (repl.js:313:29)
    at bound (domain.js:280:14)
    at REPLServer.runBound [as eval] (domain.js:293:12)
    at REPLServer.<anonymous> (repl.js:513:10)
    at emitOne (events.js:101:20)
```

Behavior proposed by this PR:

```
> const dottie = require('./dottie')
undefined
> dottie.get({}, undefined)
undefined
> dottie.get({}, null)
undefined
> dottie.get({}, null, 'default')
'default'
```