### PR TITLE
Include null keys in paths response

### DIFF
--- a/dottie.js
+++ b/dottie.js
@@ -198,7 +198,7 @@
       for (key in object) {
         value = object[key];
 
-        if (typeof value === 'object') {
+        if (typeof value === 'object' && value !== null) {
           paths = paths.concat(Dottie.paths(value, prefixes.concat([key])));
         } else {
           paths.push(prefixes.concat(key).join('.'));

--- a/test/paths.test.js
+++ b/test/paths.test.js
@@ -23,4 +23,13 @@ describe("dottie.paths", function() {
 
     expect(dottie.paths(object)).to.eql(["a", "b.c", "b.d.e"]);
   });
+
+  it("includes keys of null objects", function() {
+    var object = {
+      nonNullKey: 1,
+      nullKey: null
+    };
+
+    expect(dottie.paths(object)).to.eql(["nonNullKey", "nullKey"]);
+  });
 });


### PR DESCRIPTION
#15 has missed to fix it for `Dottie.paths` method