### PR TITLE
Setting a null value should convert it to object

### DIFF
--- a/dottie.js
+++ b/dottie.js
@@ -82,7 +82,7 @@
 
       // Create namespace (object) where none exists.
       // If `force === true`, bruteforce the path without throwing errors.
-      if (!hasOwnProp.call(current, piece) || current[piece] === undefined || (typeof current[piece] !== 'object' && options && options.force === true)) {
+      if (!hasOwnProp.call(current, piece) || current[piece] === undefined || current[piece] === null || (typeof current[piece] !== 'object' && options && options.force === true)) {
         current[piece] = {};
       }
 

--- a/dottie.js
+++ b/dottie.js
@@ -82,7 +82,10 @@
 
       // Create namespace (object) where none exists.
       // If `force === true`, bruteforce the path without throwing errors.
-      if (!hasOwnProp.call(current, piece) || current[piece] === undefined || current[piece] === null || (typeof current[piece] !== 'object' && options && options.force === true)) {
+      if (
+        !hasOwnProp.call(current, piece)
+        || current[piece] === undefined
+        || ((typeof current[piece] !== 'object' || current[piece] === null) && options && options.force === true)) {
         current[piece] = {};
       }
 
@@ -91,7 +94,7 @@
         current[piece] = value;
       } else {
         // We do not overwrite existing path pieces by default
-        if (typeof current[piece] !== 'object') {
+        if (typeof current[piece] !== 'object' || current[piece] === null) {
           throw new Error('Target key "' + piece + '" is not suitable for a nested value. (It is in use as non-object. Set `force` to `true` to override.)');
         }
 

--- a/test/set.test.js
+++ b/test/set.test.js
@@ -28,12 +28,23 @@ describe("dottie.set", function () {
     expect(data.values.level1).to.equal('foo');
   });
 
-  it("should handle setting a nested value on an null value (should convert null to object)", function () {
+  it("should throw when overwriting a nested null value with force: false", function () {
     var data = {
       'values': null
     };
 
-    dottie.set(data, 'values.level1', 'foo');
+
+    expect(function () {
+      dottie.set(data, 'values.level1', 'foo');
+    }).to.throw();
+  });
+
+  it("should handle setting a nested value on an null value (should convert null to object) with force: true", function () {
+    var data = {
+      'values': null
+    };
+
+    dottie.set(data, 'values.level1', 'foo', { force: true });
     expect(data.values.level1).to.equal('foo');
   });
 

--- a/test/set.test.js
+++ b/test/set.test.js
@@ -28,12 +28,21 @@ describe("dottie.set", function () {
     expect(data.values.level1).to.equal('foo');
   });
 
+  it("should handle setting a nested value on an null value (should convert null to object)", function () {
+    var data = {
+      'values': null
+    };
+
+    dottie.set(data, 'values.level1', 'foo');
+    expect(data.values.level1).to.equal('foo');
+  });
+
   it('should be able to set with an array path', function () {
     dottie.set(data, ['some.dot.containing', 'value'], 'razzamataz');
     expect(data['some.dot.containing'].value).to.equal('razzamataz');
   });
 
-  it("should throw error when setting a nested value on an existing key with a non-object value", function() {
+  it("should throw error when setting a nested value on an existing key with a non-object value", function () {
     expect(function () {
       dottie.set(data, 'foo.bar.baz', 'someValue');
     }).to.throw();


### PR DESCRIPTION
Setting a null value should convert it to object (like it works for undefined values).